### PR TITLE
Ignore route unexistence

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,7 +97,7 @@ pipeline {
                     script
                     {
 			sh """
-			   oc delete route nodejs-image-demo
+			   oc delete route nodejs-image-demo --ignore-not-found
                        	   oc expose svc/nodejs-image-demo
 			"""
                     } // script


### PR DESCRIPTION
If the app is created at the first time, the DEPLOY pipeline will fail because the route never existed